### PR TITLE
eilmeldung: fix crossbuild

### DIFF
--- a/srcpkgs/eilmeldung/template
+++ b/srcpkgs/eilmeldung/template
@@ -1,0 +1,18 @@
+# Template file for 'eilmeldung'
+pkgname=eilmeldung
+version=1.1.0
+revision=1
+build_style=cargo
+hostmakedepends="pkg-config libclang clang"
+makedepends="libxml2-devel openssl-devel sqlite-devel libsixel-devel oniguruma-devel"
+short_desc="TUI RSS reader based on the news-flash library"
+maintainer="Vitali Kaplich <vitalik.kaplich@yandex.by>"
+license="GPL-3.0-or-later"
+homepage="https://github.com/christo-auer/eilmeldung"
+changelog="https://github.com/christo-auer/eilmeldung/releases"
+distfiles="https://github.com/christo-auer/eilmeldung/archive/refs/tags/${version}.tar.gz"
+checksum=566aa7ec5477cd66ecf88a30f3faaeb84f873628dd11e5724f54a89677298b3c
+
+post_install() {
+	vlicense LICENSE
+}


### PR DESCRIPTION
New commit fixing aarch64, aarch64-musl builds.

Testing the changes

- I tested the changes in this PR: **Yes**

Local build testing

- I built this PR locally for my native architecture (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl
  - aarch64
  - aarch-musl