### PR TITLE
spotatui: update to 0.38.0

### DIFF
--- a/srcpkgs/spotatui/template
+++ b/srcpkgs/spotatui/template
@@ -1,6 +1,6 @@
 # Template file for 'spotatui'
 pkgname=spotatui
-version=0.37.3
+version=0.38.0
 revision=1
 build_style=cargo
 hostmakedepends="pkg-config cmake clang rust-bindgen"
@@ -11,7 +11,7 @@ license="MIT"
 homepage="https://github.com/LargeModGames/spotatui"
 changelog="https://github.com/LargeModGames/spotatui/releases/tag/v${version}"
 distfiles="https://github.com/LargeModGames/spotatui/archive/refs/tags/v${version}.tar.gz"
-checksum=519aac2f0ae618557ae578934d060ad590fde4624cb53eaf071be199ec76d594
+checksum=46d92822c03306d1b7b28d6b9bac2c1a4e8626b8e8fd4ad3aa5aa00f17a6bf10
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
Testing the changes

- I tested the changes in this PR: **YES**

Local build testing

- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl (crossbuild)
  - aarch64-glibc (crossbuild)
  - x86_64-musl (native)
