### PR TITLE
 fsel: update to 3.3.1

### DIFF
--- a/srcpkgs/fsel/template
+++ b/srcpkgs/fsel/template
@@ -1,6 +1,6 @@
 # Template file for 'fsel'
 pkgname=fsel
-version=3.2.0
+version=3.3.1
 revision=1
 build_style=cargo
 short_desc="Terminal file and app launcher with dmenu and clipboard features"
@@ -9,7 +9,7 @@ license="BSD-2-Clause"
 homepage="https://github.com/Mjoyufull/fsel"
 changelog="https://github.com/Mjoyufull/fsel/releases"
 distfiles="https://github.com/Mjoyufull/fsel/archive/refs/tags/${version}.tar.gz"
-checksum=5a71449e89a0612d940e325fb26023bb298c82ff12685ce83f695ed54e7a9a16
+checksum=adc5a9d10fb46602bc07b35883517af868e1ddf9f467ebc0feed924022ca12a0
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
Testing the changes

- I tested the changes in this PR: YES

Local build testing

- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl (crossbuild)
  - aarch64-glibc (crossbuild)
  - x86_64-musl (native)
