### PR TITLE
new package: pass-cli-0.17.21

### DIFF
--- a/srcpkgs/pass-cli/template
+++ b/srcpkgs/pass-cli/template
@@ -1,0 +1,15 @@
+# Template file for 'pass-cli'
+pkgname=pass-cli
+version=0.17.21
+revision=1
+build_style=go
+go_import_path=github.com/arimxyer/pass-cli
+go_ldflags="-X pass-cli/cmd.version=$version"
+short_desc="Password and API key manager for folks who live in the command line"
+maintainer="Nizarjh <chel773@tutamail.com>"
+license=Apache-2.0
+homepage=https://github.com/arimxyer/pass-cli
+changelog=https://raw.githubusercontent.com/arimxyer/pass-cli/refs/heads/main/CHANGELOG.md
+distfiles=https://github.com/arimxyer/pass-cli/archive/v$version/pass-cli-v$version.tar.gz
+checksum=f6192fc62cbc2789289e444327af1071292d0d25fe7edb0d9e6517aaabc1d7a6
+make_check=no #Tests require DBus and interactive input, unavailable in build environment


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!-- Rules: target `manual` if the resulting .xbps package is ≥100 MB or requires ≥8 GB RAM to build, else `main` branch. Follow [blackhole-vl/CONTRIBUTING.md](https://github.com/Event-Horizon-VL/blackhole-vl/blob/main/CONTRIBUTING.md). -->

#### New package
- This new package conforms to the [our](https://github.com/Event-Horizon-VL/blackhole-vl/blob/main/CONTRIBUTING.md) rules: **YES**



#### Local build testing
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-glibc(native)

closes #105 