### PR TITLE
New package: hiddify-bin-4.1.1

### DIFF
--- a/srcpkgs/hiddify-bin/template
+++ b/srcpkgs/hiddify-bin/template
@@ -1,0 +1,31 @@
+# Template file for 'hiddify-bin'
+pkgname=hiddify-bin
+version=4.1.1
+revision=1
+archs="x86_64"
+hostmakedepends="tar xz zstd"
+depends="at-spi2-core cairo curl fontconfig glib glibc gtk+3 libayatana-appindicator libepoxy libgcc libstdc++ libffi pango"
+short_desc="Multi-platform auto-proxy client"
+maintainer="nerdyslacker <karyan40024@gmail.com>"
+license="GPL-3.0-or-later"
+homepage="https://hiddify.com"
+distfiles="https://github.com/hiddify/hiddify-app/releases/download/v${version}/Hiddify-Debian-x64.deb"
+checksum=e622abd15f7d4410c5655f3fdcd0fa9300944666fa40ac22761f06f93020f10e
+nopie=yes
+noverifyrdeps=yes
+noshlibprovides=yes
+
+do_extract() {
+	mkdir -p ${DESTDIR}
+	ar x ${XBPS_SRCDISTDIR}/${pkgname}-${version}/Hiddify-Debian-x64.deb
+	tar --zstd -xf data.tar.zst -C ${DESTDIR}
+}
+
+do_install() {
+	vmkdir opt/hiddify/
+	mv ${DESTDIR}/usr/share/hiddify/* ${DESTDIR}/opt/hiddify/
+
+	vmkdir usr/bin/
+	ln -s /opt/hiddify/hiddify ${DESTDIR}/usr/bin/
+	ln -s /opt/hiddify/HiddifyCli ${DESTDIR}/usr/bin/
+}


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!-- Rules: target `manual` if the resulting .xbps package is ≥100 MB or requires ≥8 GB RAM to build, else `main` branch. Follow [blackhole-vl/CONTRIBUTING.md](https://github.com/Event-Horizon-VL/blackhole-vl/blob/main/CONTRIBUTING.md). -->

#### New package
- This new package conforms to the [our](https://github.com/Event-Horizon-VL/blackhole-vl/blob/main/CONTRIBUTING.md) rules: **YES**

#### Local build testing
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-glibc(native)
  
  closes #30 