### PR TITLE
New package: protobuf-go-1.36.11

### DIFF
--- a/srcpkgs/protobuf-go/template
+++ b/srcpkgs/protobuf-go/template
@@ -1,0 +1,20 @@
+# Template file for 'protobuf-go'
+pkgname=protobuf-go
+version=1.36.11
+revision=1
+build_style=go
+go_import_path="google.golang.org/protobuf"
+go_package="./cmd/protoc-gen-go"
+depends="protobuf"
+short_desc="Go support for Google's protocol buffers"
+maintainer="nerdyslacker <karyan40024@gmail.com>"
+license="BSD-3-Clause"
+homepage="https://github.com/protocolbuffers/protobuf-go"
+changelog="https://github.com/protocolbuffers/protobuf-go/releases"
+distfiles="https://github.com/protocolbuffers/protobuf-go/archive/refs/tags/v${version}.tar.gz"
+checksum=517b935001f3d43640489cd1aab531a3ed5927fb34379fa6cb1c1a514e9cb8e8
+
+post_install() {
+	vlicense LICENSE
+	vdoc README.md
+}


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!-- Rules: target `manual` if the resulting .xbps package is ≥100 MB or requires ≥8 GB RAM to build, else `main` branch. Follow [blackhole-vl/CONTRIBUTING.md](https://github.com/Event-Horizon-VL/blackhole-vl/blob/main/CONTRIBUTING.md). -->
<!--
Uncomment if block below is a new package:
#### New package
- This new package conforms to the [our](https://github.com/Event-Horizon-VL/blackhole-vl/blob/main/CONTRIBUTING.md) rules: **YES**|**NO**
-->

#### Local build testing
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl(crossbuild)
  - aarch64-glibc(crossbuild)
  - x86_64-musl(crossbuild)
  - x86_64-glibc(native)

Closes: #188 