### PR TITLE
hyprmoncfg: update to 1.7.0

### DIFF
--- a/srcpkgs/hyprmoncfg/template
+++ b/srcpkgs/hyprmoncfg/template
@@ -1,6 +1,6 @@
 # Template file for 'hyprmoncfg'
 pkgname=hyprmoncfg
-version=1.4.2
+version=1.7.0
 revision=1
 build_style=go
 go_import_path=github.com/crmne/hyprmoncfg
@@ -11,7 +11,7 @@ maintainer="Kirilla39 <kirill39.pesin@ya.ru>"
 license="MIT"
 homepage="https://github.com/crmne/hyprmoncfg/"
 distfiles="https://github.com/crmne/hyprmoncfg/archive/v${version}.tar.gz"
-checksum=013458c5119155b053d9fbb5dcaaf6d42ced6affab354b656016ac17ddb6efa6
+checksum=f2b8f2d1feb48994dea61ba12fbaead99ac28c1850bb18ccdd46a2e89b9a08a9
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
Updates hyprmoncfg from 1.4.2 to 1.7.0.

The checksum is for the upstream GitHub source archive at `https://github.com/crmne/hyprmoncfg/archive/v1.7.0.tar.gz`.