### PR TITLE
Fixed the command in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Currently packages are tested on / crosscompiled for the following architectures
    (replace the architecture as needed):
 
     ```
-    sudo sed -i "1i repository=https://mirror.black-hole.dev/$(uname -m)" 00-repository-main.conf
+    sudo sed -i "1i repository=https://mirror.black-hole.dev/$(xbps-uhelper arch)" 00-repository-main.conf
     ```
 
 2. Refresh repositories and accept the fingerprint:


### PR DESCRIPTION
Fixed the command in section "Prebuilt binaries" to add support for musl.
On musl, `uname -m` returns `x86_64`, whereas `xbps-uhelper arch` returns `x86_64-musl`; the same applies to aarch64

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**