### PR TITLE
netwatch: update to 0.28.1

### DIFF
--- a/srcpkgs/netwatch/template
+++ b/srcpkgs/netwatch/template
@@ -1,6 +1,6 @@
 # Template file for 'netwatch'
 pkgname=netwatch
-version=0.26.1
+version=0.28.1
 revision=1
 build_style=cargo
 hostmakedepends="pkg-config"
@@ -11,7 +11,7 @@ license="MIT"
 homepage="https://www.netwatchlabs.com"
 changelog="https://raw.githubusercontent.com/matthart1983/netwatch/refs/heads/main/CHANGELOG.md"
 distfiles="https://github.com/matthart1983/netwatch/archive/refs/tags/v${version}.tar.gz"
-checksum=3600dadbba659d56d2dede32a384923ebf3cdf91af96c13b1efdaaee23302ba9
+checksum=db428f9a85b930a37da33e2bd3ff9dd13c867de3e222e70a20c29e2fd3d5378e
 
 post_install() {
 	vdoc README.md


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!-- Rules: target `manual` if the resulting .xbps package is ≥100 MB or requires ≥8 GB RAM to build, else `main` branch. Follow [blackhole-vl/CONTRIBUTING.md](https://github.com/Event-Horizon-VL/blackhole-vl/blob/main/CONTRIBUTING.md). -->
<!--
Uncomment if block below is a new package:
#### New package
- This new package conforms to the [our](https://github.com/Event-Horizon-VL/blackhole-vl/blob/main/CONTRIBUTING.md) rules: **YES**|**NO**
-->

#### Local build testing
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-glibc(native)
