### PR TITLE
hyprmoncfg: updated to 1.16.1

### DIFF
--- a/srcpkgs/hyprmoncfg/template
+++ b/srcpkgs/hyprmoncfg/template
@@ -1,6 +1,6 @@
 # Template file for 'hyprmoncfg'
 pkgname=hyprmoncfg
-version=1.12.0
+version=1.16.1
 revision=1
 build_style=go
 go_import_path=github.com/crmne/hyprmoncfg
@@ -11,7 +11,7 @@ maintainer="Kirilla39 <kirill39.pesin@ya.ru>"
 license="MIT"
 homepage="https://github.com/crmne/hyprmoncfg/"
 distfiles="https://github.com/crmne/hyprmoncfg/archive/v${version}.tar.gz"
-checksum=4dc7011c3111cfd0a31da71243b85545f730cb97e1c9796fd268fa0876a0d5a2
+checksum=af2c1255412b15212b1aad976e7845d1f25efcac86ecc7e45c38973f9a6dbe20
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **NO**

<!-- Rules: target `manual` if the resulting .xbps package is ≥100 MB or requires ≥8 GB RAM to build, else `main` branch. Follow [blackhole-vl/CONTRIBUTING.md](https://github.com/Event-Horizon-VL/blackhole-vl/blob/main/CONTRIBUTING.md). -->
<!--
Uncomment if block below is a new package:
#### New package
- This new package conforms to the [our](https://github.com/Event-Horizon-VL/blackhole-vl/blob/main/CONTRIBUTING.md) rules: **YES**|**NO**
-->

<!--
#### Local build testing
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl(crossbuild|native)
  - aarch64-glibc(crossbuild|native)
  - x86_64-musl(crossbuild|native)
  - x86_64-glibc(crossbuild|native)
-->