### PR TITLE
hyprmoncfg: update to 1.18.2.

### DIFF
--- a/srcpkgs/hyprmoncfg/template
+++ b/srcpkgs/hyprmoncfg/template
@@ -1,6 +1,6 @@
 # Template file for 'hyprmoncfg'
 pkgname=hyprmoncfg
-version=1.17.1
+version=1.18.2
 revision=1
 build_style=go
 go_import_path=github.com/crmne/hyprmoncfg
@@ -11,7 +11,7 @@ maintainer="Kirilla39 <kirill39.pesin@ya.ru>"
 license="MIT"
 homepage="https://github.com/crmne/hyprmoncfg/"
 distfiles="https://github.com/crmne/hyprmoncfg/archive/v${version}.tar.gz"
-checksum=9d0cefd66f20b0cbf7eef4be846528713f020be27e8f05591fe0b4e47627afc4
+checksum=7b8012ca10c82ee9ba4a985f50354dd9a9201efb7853ef6b2a01a469178547c7
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
Update the existing package to [hyprmoncfg 1.18.2](https://github.com/crmne/hyprmoncfg/releases/tag/v1.18.2): stable wake reconciliation, complete preview rollback, native Omarchy laptop-display integration, and matching TUI colour terminology.

#### Testing the changes
- I tested the changes in this PR: **briefly**
- Verified the upstream source checksum and shell syntax.
- The upstream Go test suite and offline source build pass on x86_64 Linux.
- A full local XBPS build was not run; package builds remain for this repository's CI.

Targets `main`; the two Go binaries are well below 100 MB and the build does not require 8 GB RAM.